### PR TITLE
Refactor AList attachment handler and AList verification

### DIFF
--- a/src/main/java/run/halo/alist/config/AListProperties.java
+++ b/src/main/java/run/halo/alist/config/AListProperties.java
@@ -1,5 +1,7 @@
 package run.halo.alist.config;
 
+import jakarta.validation.constraints.NotBlank;
+import java.net.URL;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,25 +19,22 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class AListProperties {
+
     /**
      * AList 站点地址.
      */
-    private String site;
+    @NotBlank
+    private URL site;
+
     /**
      * AList 基本路径下文件夹的路径.
      */
     private String path;
+
     /**
      * Secret name.
      */
+    @NotBlank
     private String secretName;
 
-    /**
-     * 获取 token key.
-     *
-     * @return token key
-     */
-    public String getTokenKey() {
-        return site + secretName;
-    }
 }

--- a/src/main/java/run/halo/alist/controller/PolicyConfigValidationController.java
+++ b/src/main/java/run/halo/alist/controller/PolicyConfigValidationController.java
@@ -1,20 +1,22 @@
 package run.halo.alist.controller;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 import run.halo.alist.config.AListProperties;
 import run.halo.alist.dto.AListResult;
-import run.halo.alist.dto.request.AListGetFileInfoReq;
 import run.halo.alist.dto.response.AListGetCurrentUserInfoRes;
-import run.halo.alist.dto.response.AListGetFileInfoRes;
 import run.halo.alist.endpoint.AListAttachmentHandler;
-import run.halo.alist.exception.AListIllegalArgumentException;
+import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.plugin.ApiVersion;
 
 /**
@@ -29,79 +31,61 @@ import run.halo.app.plugin.ApiVersion;
 @RequiredArgsConstructor
 @Slf4j
 public class PolicyConfigValidationController {
+
     private final AListAttachmentHandler handler;
 
+    private final ReactiveExtensionClient client;
+
     @PostMapping("/configs/-/verify")
-    public Mono<Void> validatePolicyConfig(@RequestBody AListProperties properties) {
-        return handler.removeTokenCache(properties)
-            .then(
-                handler.auth(properties)
-                    .flatMap(token -> handler.getWebClients()
-                        .get(properties.getSite())
-                        .get()
-                        .uri("/api/me")
-                        .header(HttpHeaders.AUTHORIZATION, token)
-                        .retrieve()
-                        .bodyToMono(
-                            new ParameterizedTypeReference<AListResult<AListGetCurrentUserInfoRes>>() {
-                            })
-                        .flatMap(response -> {
-                            if (response.getCode().equals("401")) {
-                                return Mono.error(new AListIllegalArgumentException(
-                                    "Current user is disabled"));
-                            }
-                            if (!response.getCode().equals("200")) {
-                                return Mono.error(new AListIllegalArgumentException(
-                                    "Wrong Username Or Password"));
-                            }
-                            AListGetCurrentUserInfoRes userInfo = response.getData();
-                            return handler.getWebClients()
-                                .get(properties.getSite())
-                                .post()
-                                .uri("/api/fs/get")
-                                .header(HttpHeaders.AUTHORIZATION, token)
-                                .body(Mono.just(AListGetFileInfoReq.builder()
-                                        .path("/")
-                                        .build()),
-                                    AListGetFileInfoReq.class)
-                                .retrieve()
-                                .bodyToMono(
-                                    new ParameterizedTypeReference<AListResult<AListGetFileInfoRes>>() {
-                                    })
-                                .flatMap(res -> {
-                                    // 验证当前基本路径是否可用
-                                    if (!res.getCode().equals("200")) {
-                                        return Mono.error(
-                                            new AListIllegalArgumentException(res.getMessage()));
-                                    }
-                                    // 管理员用户拥有所有权限
-                                    if (userInfo.getRole() == 2) {
-                                        return Mono.empty();
-                                    }
-                                    // 普通用户验证权限
-                                    int permission = userInfo.getPermission();
-                                    StringBuilder sb = new StringBuilder();
-                                    if ((permission & 2) == 0) {
-                                        sb.append("无需密码访问权限 ");
-                                    }
-                                    if ((permission & 8) == 0) {
-                                        sb.append("创建目录或上传权限 ");
-                                    }
-                                    if ((permission & 128) == 0) {
-                                        sb.append("删除权限 ");
-                                    }
-                                    if (!sb.isEmpty()) {
-                                        sb.append("未开启");
-                                        return Mono.error(
-                                            new AListIllegalArgumentException(sb.toString()));
-                                    }
-                                    return Mono.empty();
-                                });
-
+    public Mono<AListGetCurrentUserInfoRes> validatePolicyConfig(
+        @RequestBody AListProperties properties) {
+        // check if the current user has permissions
+        return handler.getToken(properties)
+            .flatMap(token -> {
+                var getMeUri = UriComponentsBuilder.fromHttpUrl(properties.getSite().toString())
+                    .path("/api/me")
+                    .toUriString();
+                return handler.getWebClient().get().uri(getMeUri)
+                    .header(HttpHeaders.AUTHORIZATION, token)
+                    .retrieve()
+                    .bodyToMono(
+                        new ParameterizedTypeReference<AListResult<AListGetCurrentUserInfoRes>>() {
                         })
-
-                    )
-            );
+                    .flatMap(result -> {
+                        if (!Objects.equals(HttpStatus.OK.value(), result.getCode())) {
+                            return Mono.error(
+                                new ServerWebInputException(
+                                    "Failed to get AList user info: " + result.getMessage()
+                                )
+                            );
+                        }
+                        return Mono.just(result.getData());
+                    })
+                    .flatMap(userInfo -> {
+                        if (userInfo.isDisabled()) {
+                            return Mono.error(
+                                new ServerWebInputException("Current user is disabled")
+                            );
+                        }
+                        // role = 2 means admin which permissions is 0.
+                        if (userInfo.getRole() != 2) {
+                            int perm = userInfo.getPermission();
+                            // Permission "Make dir or upload": 0b1000 = 8
+                            // Permission "Delete": 0b1000_0000 = 128
+                            if ((perm & 0b1000_0000) == 0 || (perm & 0b1000) == 0) {
+                                return Mono.error(
+                                    new ServerWebInputException("""
+                                        Current user has insufficient permissions. \
+                                        Make sure select "Make dir or upload" and "Delete" \
+                                        permissions for the user in AList.\
+                                        """
+                                    )
+                                );
+                            }
+                        }
+                        return Mono.just(userInfo);
+                    });
+            });
     }
 }
 

--- a/src/main/java/run/halo/alist/dto/AListResult.java
+++ b/src/main/java/run/halo/alist/dto/AListResult.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class AListResult <T>{
-    private String code;
+    private Integer code;
     private String message;
     private T data;
 }

--- a/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
+++ b/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
@@ -1,32 +1,29 @@
 package run.halo.alist.endpoint;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
+
 import io.netty.channel.ChannelOption;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.pf4j.Extension;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.server.ServerWebInputException;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.web.util.UriUtils;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import run.halo.alist.config.AListProperties;
@@ -34,14 +31,9 @@ import run.halo.alist.dto.AListResult;
 import run.halo.alist.dto.request.AListGetFileInfoReq;
 import run.halo.alist.dto.request.AListLoginReq;
 import run.halo.alist.dto.request.AListRemoveFileReq;
-import run.halo.alist.dto.response.AListGetCurrentUserInfoRes;
 import run.halo.alist.dto.response.AListGetFileInfoRes;
 import run.halo.alist.dto.response.AListLoginRes;
-import run.halo.alist.dto.response.AListUploadAsTaskRes;
-import run.halo.alist.exception.AListIllegalArgumentException;
-import run.halo.alist.exception.AListRequestErrorException;
 import run.halo.app.core.extension.attachment.Attachment;
-import run.halo.app.core.extension.attachment.Constant;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.core.extension.attachment.endpoint.AttachmentHandler;
 import run.halo.app.extension.ConfigMap;
@@ -62,179 +54,181 @@ import run.halo.app.infra.utils.JsonUtils;
 @Component
 public class AListAttachmentHandler implements AttachmentHandler {
 
+    public static final String FILE_PATH_ANNO = "alist.storage.halo.run/file-path";
+
     private final ReactiveExtensionClient client;
 
-    private AListProperties properties;
-
     @Getter
-    private final Map<String, WebClient> webClients;
-
-    private final Cache<String, String> tokenCache;
+    private final WebClient webClient;
 
     public AListAttachmentHandler(ReactiveExtensionClient client) {
         this.client = client;
-        this.webClients = new HashMap<>();
-        this.tokenCache = Caffeine.newBuilder()
-            .expireAfterWrite(1, TimeUnit.DAYS)
+        var httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+            .responseTimeout(Duration.ofHours(1));
+        this.webClient = WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
             .build();
     }
 
     @Override
     public Mono<Attachment> upload(UploadContext uploadContext) {
-        FilePart file = uploadContext.file();
         return Mono.just(uploadContext)
             .filter(context -> this.shouldHandle(context.policy()))
-            .map(UploadContext::configMap)
-            .map(this::getProperties)
-            .flatMap(this::auth)
-            .flatMap(token -> file.content()
-                .map(dataBuffer -> (long) dataBuffer.readableByteCount())
-                .reduce(Long::sum)
-                .flatMap(fileSize -> webClients.get(properties.getSite())
-                    .put()
-                    .uri("/api/fs/put")
-                    .header(HttpHeaders.AUTHORIZATION, token)
-                    .header("File-Path", UriUtils.encodePath(
-                        properties.getPath() + "/" + file.name(),
-                        StandardCharsets.UTF_8))
-                    .header("As-Task", "true")
-                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                    .contentLength(fileSize)
-                    .body(file.content(), DataBuffer.class)
-                    .retrieve()
-                    .bodyToMono(
-                        new ParameterizedTypeReference<AListResult<AListUploadAsTaskRes>>() {
-                        })
-                    .flatMap(response -> {
-                        if (response.getCode().equals("200")) {
-                            log.info("[AList Info] :  Upload file {} successfully",
-                                file.name());
-                            return Mono.just(fileSize);
-                        }
-                        return Mono.error(new AListRequestErrorException(response.getMessage()));
-                    }))
-            )
-            .map(fileSize -> {
-                var metadata = new Metadata();
-                metadata.setName(UUID.randomUUID().toString());
-                metadata.setAnnotations(
-                    Map.of(Constant.EXTERNAL_LINK_ANNO_KEY, ""));
+            .map(context -> getProperties(context.configMap()))
+            .flatMap(properties -> {
+                var file = uploadContext.file();
+                var sizeOfContent = file.content()
+                    .map(dataBuffer -> (long) dataBuffer.readableByteCount())
+                    .reduce(Long::sum);
+                return Mono.zip(sizeOfContent, getToken(properties)).flatMap(tuple2 -> {
+                    var contentLength = tuple2.getT1();
+                    var token = tuple2.getT2();
+                    var uploadUri = fromHttpUrl(properties.getSite().toString())
+                        .path("/api/fs/put")
+                        .build()
+                        .toUri();
 
-                var spec = new Attachment.AttachmentSpec();
-                spec.setDisplayName(file.filename());
-                Optional.ofNullable(file.headers().getContentType())
-                    .map(Objects::toString)
-                    .ifPresent(spec::setMediaType);
-                spec.setSize(fileSize);
+                    return renameFilename(token, properties, file.filename()).flatMap(filename -> {
+                        var filePathBuilder =
+                            UriComponentsBuilder.fromPath(properties.getPath())
+                                .pathSegment(filename);
+                        var encodedFilePath = filePathBuilder.toUriString();
+                        var rawFilePath = filePathBuilder.build().toString();
+                        log.info("Uploading file {} to {}", filename, uploadUri);
+                        // check the file is already exists
+                        return webClient.put().uri(uploadUri)
+                            .header(HttpHeaders.AUTHORIZATION, token)
+                            .header("File-Path", encodedFilePath)
+                            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                            .contentLength(contentLength)
+                            .body(file.content(), DataBuffer.class)
+                            .retrieve()
+                            .bodyToMono(
+                                new ParameterizedTypeReference<AListResult<Void>>() {
+                                })
+                            .flatMap(result -> {
+                                if (!Objects.equals(OK.value(), result.getCode())) {
+                                    return Mono.error(new ServerWebInputException(
+                                        "Failed to upload file: " + result.getMessage())
+                                    );
+                                }
+                                log.info("Uploaded file {} to {}", filename, uploadUri);
+                                var metadata = new Metadata();
+                                metadata.setGenerateName("alist-");
+                                var annotations = new HashMap<String, String>();
+                                metadata.setAnnotations(annotations);
+                                annotations.put(FILE_PATH_ANNO, rawFilePath);
 
-                var attachment = new Attachment();
-                attachment.setMetadata(metadata);
-                attachment.setSpec(spec);
-                return attachment;
+                                var spec = new Attachment.AttachmentSpec();
+                                spec.setDisplayName(filename);
+
+                                Optional.ofNullable(file.headers().getContentType())
+                                    .map(Objects::toString)
+                                    .ifPresent(spec::setMediaType);
+                                spec.setSize(contentLength);
+
+                                var attachment = new Attachment();
+                                attachment.setMetadata(metadata);
+                                attachment.setSpec(spec);
+                                return Mono.just(attachment);
+                            });
+                    });
+                });
             });
     }
 
-    public Mono<String> auth(AListProperties properties) {
-        this.properties = properties;
-        WebClient webClient = webClients.computeIfAbsent(properties.getSite(),
-            k -> {
-                // 创建一个HttpClient实例，设置连接和读取超时时间
-                HttpClient httpClient = HttpClient.create()
-                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // 连接超时时间，单位毫秒
-                    .responseTimeout(Duration.ofMinutes(10)); // 响应超时时间
-                // 使用上面的HttpClient实例创建WebClient
-                return WebClient.builder()
-                    .baseUrl(properties.getSite())
-                    .clientConnector(new ReactorClientHttpConnector(httpClient))
-                    .build();
-            });
-
-        String secretName = properties.getSecretName();
-        if (tokenCache.getIfPresent(properties.getTokenKey()) != null) {
-            return Mono.just(
-                Objects.requireNonNull(tokenCache.getIfPresent(properties.getTokenKey())));
-        }
-
-        return client.fetch(Secret.class, secretName)
-            .switchIfEmpty(Mono.error(new AListIllegalArgumentException(
-                "Secret " + secretName + " not found")))
+    public Mono<String> getToken(AListProperties properties) {
+        return client.get(Secret.class, properties.getSecretName())
             .flatMap(secret -> {
-                var stringData = secret.getStringData();
-                var usernameKey = "username";
-                var passwordKey = "password";
-                if (stringData == null
-                    || !(stringData.containsKey(usernameKey) && stringData.containsKey(
-                    passwordKey))) {
-                    return Mono.error(new AListIllegalArgumentException(
-                        "Secret " + secretName
-                            + " does not have username or password key"));
+                var data = secret.getStringData();
+                Mono<String> credentialNotFound = Mono.error(
+                    new ServerWebInputException(
+                        "Username or password not found in secret "
+                            + secret.getMetadata().getName()
+                    )
+                );
+                if (data == null) {
+                    return credentialNotFound;
                 }
-                var username = stringData.get(usernameKey);
-                var password = stringData.get(passwordKey);
-                return webClient.post()
-                    .uri("/api/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(Mono.just(
-                        AListLoginReq.builder()
-                            .username(username)
-                            .password(password)
-                            .build()), AListLoginReq.class)
+                var username = data.get("username");
+                var password = data.get("password");
+                if (StringUtils.isAnyBlank(username, password)) {
+                    return credentialNotFound;
+                }
+
+                return Mono.just(AListLoginReq.builder()
+                    .username(username)
+                    .password(password)
+                    .build());
+            })
+            .flatMap(loginBody -> {
+                var site = properties.getSite();
+                var loginUri = fromHttpUrl(site.toString())
+                    .path("/api/auth/login")
+                    .build()
+                    .toUri();
+                return webClient.post().uri(loginUri)
+                    .bodyValue(loginBody)
                     .retrieve()
-                    .bodyToMono(
-                        new ParameterizedTypeReference<AListResult<AListLoginRes>>() {
-                        })
-                    .onErrorMap(WebClientRequestException.class,
-                        e -> new AListIllegalArgumentException(e.getMessage()));
-            }).flatMap(response -> {
-                if (response.getCode().equals("200")) {
-                    log.info("[AList Info] :  Login successfully");
-                    return Mono.just(
-                        tokenCache.get(properties.getTokenKey(),
-                            k -> response.getData().getToken()));
-                }
-                return Mono.error(new AListIllegalArgumentException(
-                    "Wrong Username Or Password"));
+                    .bodyToMono(new ParameterizedTypeReference<AListResult<AListLoginRes>>() {
+                    })
+                    .flatMap(result -> {
+                        if (!Objects.equals(OK.value(), result.getCode())) {
+                            return Mono.error(new ServerWebInputException(
+                                "Failed to login to " + site + ": " + result.getMessage()
+                            ));
+                        }
+                        return Mono.just(result.getData().getToken());
+                    });
             });
     }
 
     private AListProperties getProperties(ConfigMap configMap) {
         var settingJson = configMap.getData().getOrDefault("default", "{}");
-        AListProperties aListProperties =
-            JsonUtils.jsonToObject(settingJson, AListProperties.class);
-        if (aListProperties.getPath().equals("/")) {
-            aListProperties.setPath("");
-        }
-        return aListProperties;
+        return JsonUtils.jsonToObject(settingJson, AListProperties.class);
     }
 
     @Override
     public Mono<Attachment> delete(DeleteContext deleteContext) {
-        return Mono.just(deleteContext).filter(context -> this.shouldHandle(context.policy()))
-            .map(DeleteContext::configMap)
-            .map(this::getProperties)
-            .flatMap(this::auth)
-            .flatMap(token -> webClients.get(properties.getSite())
-                .post()
-                .uri("/api/fs/remove")
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .body(Mono.just(AListRemoveFileReq.builder()
-                    .dir(properties.getPath())
-                    .names(List.of(deleteContext.attachment().getSpec().getDisplayName()))
-                    .build()), AListGetFileInfoReq.class)
-                .retrieve()
-                .bodyToMono(
-                    new ParameterizedTypeReference<AListResult<String>>() {
-                    })
-                .flatMap(response -> {
-                    if (response.getCode().equals("200")) {
-                        log.info("[AList Info] :  Delete file {} successfully",
-                            deleteContext.attachment().getSpec().getDisplayName());
-                        return Mono.just(token);
-                    }
-                    return Mono.error(new AListRequestErrorException(response.getMessage()));
-                })
-            )
-            .map(token -> deleteContext.attachment());
+        return Mono.just(deleteContext)
+            .filter(context -> this.shouldHandle(context.policy()))
+            .flatMap(context -> {
+                var properties = getProperties(context.configMap());
+                var attachment = context.attachment();
+                var filePath = Optional.ofNullable(attachment.getMetadata().getAnnotations())
+                    .map(annotations -> annotations.get(FILE_PATH_ANNO))
+                    .orElse(null);
+                if (StringUtils.isBlank(filePath)) {
+                    return Mono.error(new IllegalArgumentException(
+                        "Invalid AList attachment: Missing file path annotation")
+                    );
+                }
+
+                var deleteUri = fromHttpUrl(properties.getSite().toString())
+                    .path("/api/fs/remove")
+                    .toUriString();
+                var body = AListRemoveFileReq.builder()
+                    .names(List.of(filePath))
+                    .build();
+
+                return getToken(properties)
+                    .flatMap(token -> webClient.post().uri(deleteUri)
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .bodyValue(body)
+                        .retrieve()
+                        .bodyToMono(new ParameterizedTypeReference<AListResult<Void>>() {
+                        })
+                        .flatMap(result -> {
+                            if (!Objects.equals(OK.value(), result.getCode())) {
+                                return Mono.error(new ServerWebInputException(
+                                    "Failed to delete file: " + result.getMessage())
+                                );
+                            }
+                            return Mono.just(attachment);
+                        })
+                    );
+            });
     }
 
     @Override
@@ -245,50 +239,89 @@ public class AListAttachmentHandler implements AttachmentHandler {
 
     @Override
     public Mono<URI> getPermalink(Attachment attachment, Policy policy, ConfigMap configMap) {
-        return Mono.just(policy).filter(this::shouldHandle)
-            .flatMap(p -> auth(getProperties(configMap)))
-            .flatMap(token -> webClients.get(properties.getSite())
-                .post()
-                .uri("/api/fs/get")
-                .header(HttpHeaders.AUTHORIZATION,
-                    tokenCache.getIfPresent(properties.getTokenKey()))
-                .body(Mono.just(
-                        AListGetFileInfoReq
-                            .builder()
-                            .path(properties.getPath() + "/" + attachment.getSpec().getDisplayName())
-                            .build()),
-                    AListGetFileInfoReq.class)
-                .retrieve()
-                .bodyToMono(
-                    new ParameterizedTypeReference<AListResult<AListGetFileInfoRes>>() {
-                    })
-                .flatMap(response -> {
-                    if (response.getCode().equals("200")) {
-                        log.info("[AList Info] :  Got file {} successfully",
-                            attachment.getSpec().getDisplayName());
-                        return Mono.just(response);
+        return Mono.just(policy)
+            .filter(this::shouldHandle)
+            .map(p -> getProperties(configMap))
+            .flatMap(properties -> {
+                var filePath = Optional.ofNullable(attachment.getMetadata().getAnnotations())
+                    .map(annotations -> annotations.get(FILE_PATH_ANNO))
+                    .filter(StringUtils::isNotBlank)
+                    .orElse(null);
+                if (filePath == null) {
+                    return Mono.error(new IllegalArgumentException(
+                        "Invalid AList attachment: Missing file path annotation")
+                    );
+                }
+                return getToken(properties)
+                    .flatMap(token -> getFile(token, filePath, properties, false))
+                    .map(AListGetFileInfoRes::getRawUrl)
+                    .map(URI::create);
+            });
+    }
+
+    private Mono<AListGetFileInfoRes> getFile(String token,
+        String filePath,
+        AListProperties properties,
+        boolean ignoreNotFound) {
+        var body = AListGetFileInfoReq.builder()
+            .path(filePath)
+            .build();
+        var fsGetUri = fromHttpUrl(properties.getSite().toString())
+            .path("/api/fs/get")
+            .toUriString();
+        return webClient.post().uri(fsGetUri)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(
+                new ParameterizedTypeReference<AListResult<AListGetFileInfoRes>>() {
+                })
+            .flatMap(result -> {
+                if (!Objects.equals(OK.value(), result.getCode())) {
+                    if (ignoreNotFound
+                        && Objects.equals(INTERNAL_SERVER_ERROR.value(), result.getCode())
+                        && "object not found".equals(result.getMessage())) {
+                        return Mono.empty();
                     }
-                    return Mono.error(new AListRequestErrorException(response.getMessage()));
-                }))
-            .flatMap(response -> webClients.get(properties.getSite())
-                .get()
-                .uri("/api/me")
-                .header(HttpHeaders.AUTHORIZATION,
-                    tokenCache.getIfPresent(properties.getTokenKey()))
-                .retrieve()
-                .bodyToMono(
-                    new ParameterizedTypeReference<AListResult<AListGetCurrentUserInfoRes>>() {
-                    })
-                .map(res -> UriComponentsBuilder.fromHttpUrl(properties.getSite())
-                    .path("/d{basePath}{path}/{name}")
-                    .queryParamIfPresent("sign",
-                        Optional.ofNullable(response.getData().getSign()).filter(s -> !s.isEmpty()))
-                    .buildAndExpand(
-                        res.getData().getBasePath(),
-                        properties.getPath(),
-                        response.getData().getName()
-                    )
-                    .toUri()));
+                    return Mono.error(new ServerWebInputException(
+                        "Failed to get file info: " + result.getMessage())
+                    );
+                }
+                return Mono.just(result.getData());
+            });
+    }
+
+    private Mono<String> renameFilename(String token, AListProperties properties,
+        String originalFilename) {
+        return renameFilename(token, properties, originalFilename, 0);
+    }
+
+    private Mono<String> renameFilename(String token,
+        AListProperties properties,
+        String originalFilename,
+        int index) {
+        var filename = renameFilename(originalFilename, index);
+        var filePath = UriComponentsBuilder.fromPath(properties.getPath())
+            .pathSegment(filename)
+            .build()
+            .toString();
+
+        return getFile(token, filePath, properties, true)
+            .flatMap(file -> renameFilename(token, properties, originalFilename, index + 1))
+            .switchIfEmpty(Mono.just(filename));
+    }
+
+    private static String renameFilename(String filename, int index) {
+        if (index <= 0) {
+            return filename;
+        }
+        var lastDotIndex = filename.lastIndexOf('.');
+        if (lastDotIndex == -1 || filename.startsWith(".")) {
+            return filename + "_" + index;
+        }
+        var baseName = filename.substring(0, lastDotIndex);
+        var extension = filename.substring(lastDotIndex);
+        return baseName + "_" + index + extension;
     }
 
     boolean shouldHandle(Policy policy) {
@@ -298,11 +331,6 @@ public class AListAttachmentHandler implements AttachmentHandler {
         }
         String templateName = policy.getSpec().getTemplateName();
         return "alist".equals(templateName);
-    }
-
-    public Mono<Void> removeTokenCache(AListProperties properties) {
-        tokenCache.invalidate(properties.getTokenKey());
-        return Mono.empty();
     }
 
 }


### PR DESCRIPTION
This PR wholly refactors AList attachment handler and AList verification.

After uploading an attachment, we will put the annotation `alist.storage.halo.run/file-path` into attachment annotations. Then we can use it while getting permalink and deleting it instead of use `spec.displayName`.

BYW, the caches of tokens and WebClients are removed because I think they are unnecessary in this situation and they may cause some problems unexpected. If we encountered the performance issue in the future, the feature would be considered again.

Meanwhile, uploading file will be renamed automatically if it's name already exists.

/kind improvement

Fixes #13
Fixes #16 

```release-note
解决上传成功后无法立即访问附件的问题
```