### PR TITLE
Fix the problem of not being able to upload if folder doesn't exist

### DIFF
--- a/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
+++ b/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
@@ -279,7 +279,9 @@ public class AListAttachmentHandler implements AttachmentHandler {
                 if (!Objects.equals(OK.value(), result.getCode())) {
                     if (ignoreNotFound
                         && Objects.equals(INTERNAL_SERVER_ERROR.value(), result.getCode())
-                        && "object not found".equals(result.getMessage())) {
+                        // According to https://alist.nn.ci/guide/api/fs.html, we have no better
+                        // way to determine whether the file exists
+                        && StringUtils.endsWith(result.getMessage(), "object not found")) {
                         return Mono.empty();
                     }
                     return Mono.error(new ServerWebInputException(


### PR DESCRIPTION
If the folder in AList doesn't exist, `failed get parent list: failed get dir: object not found` will be responded.

Fixes https://github.com/halo-sigs/plugin-alist/issues/24

/kind bug

```release-note
修复文件夹不存在时无法正常上传文件
```