### PR TITLE
Fix the problem of not being able to delete if storage was deleted

### DIFF
--- a/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
+++ b/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
@@ -220,6 +220,14 @@ public class AListAttachmentHandler implements AttachmentHandler {
                         })
                         .flatMap(result -> {
                             if (!Objects.equals(OK.value(), result.getCode())) {
+                                // According to https://alist.nn.ci/guide/api/fs.html, we have no
+                                // better way to detect whether the storage is not found
+                                if (StringUtils.startsWith(
+                                    result.getMessage(), "failed get storage: storage not found"
+                                )) {
+                                    // ignore error: storage not found
+                                    return Mono.just(attachment);
+                                }
                                 return Mono.error(new ServerWebInputException(
                                     "Failed to delete file: " + result.getMessage())
                                 );


### PR DESCRIPTION
This PR ignores the error `failed get storage: storage not found; rawPath: ...` while deleting attachments.

Fixes #25 

/kind bug

```release-note
修复因 AList 存储被删除后无法删除附件的问题
```