### PR TITLE
feat: support attachment URL prefix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,6 @@ sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/releases' }
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
-    maven { url 'https://repo.spring.io/milestone' }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.20.8-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.20.20')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.4
+version=1.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.2
+version=1.1.4

--- a/src/main/java/run/halo/alist/config/AListProperties.java
+++ b/src/main/java/run/halo/alist/config/AListProperties.java
@@ -27,9 +27,9 @@ public class AListProperties {
     private URL site;
 
     /**
-     * 附件访问前缀.
+     * 外部访问链接.
      */
-    private URL attachmentUrlPrefix;
+    private URL externalUrl;
 
     /**
      * AList 基本路径下文件夹的路径.

--- a/src/main/java/run/halo/alist/config/AListProperties.java
+++ b/src/main/java/run/halo/alist/config/AListProperties.java
@@ -27,6 +27,11 @@ public class AListProperties {
     private URL site;
 
     /**
+     * 附件访问前缀.
+     */
+    private URL attachmentUrlPrefix;
+
+    /**
      * AList 基本路径下文件夹的路径.
      */
     private String path;

--- a/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
+++ b/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
@@ -296,12 +296,13 @@ public class AListAttachmentHandler implements AttachmentHandler {
 
     private String getExternalUrl(AListProperties properties,
         AListGetCurrentUserInfoRes userInfoRes) {
-        return properties.getExternalUrl() != null
+        String base = properties.getExternalUrl() != null
             ? properties.getExternalUrl().toString()
             : fromUriString(properties.getSite().toString())
                 .path("/d{basePath}")
                 .buildAndExpand(userInfoRes.getBasePath())
                 .toUriString();
+        return StringUtils.removeEnd(base, "/");
     }
 
     private Mono<AListGetFileInfoRes> getFile(String token,

--- a/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
+++ b/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
@@ -280,19 +280,28 @@ public class AListAttachmentHandler implements AttachmentHandler {
                                 new ParameterizedTypeReference<AListResult<AListGetCurrentUserInfoRes>>() {
                                 })
                             .map(userInfoRes -> fromUriString(
-                                    properties.getSite().toString())
-                                .path("/d{basePath}{path}/{name}")
+                                    getAttachmentUrlPrefix(properties, userInfoRes.getData()))
+                                .path("{path}/{name}")
                                 .queryParamIfPresent("sign",
                                     Optional.ofNullable(fileInfo.getSign())
                                         .filter(s -> !s.isEmpty()))
                                 .buildAndExpand(
-                                    userInfoRes.getData().getBasePath(),
                                     "/".equals(properties.getPath())? "" : properties.getPath(),
                                     fileInfo.getName()
                                 )
                                 .toUri());
                     });
             });
+    }
+
+    private String getAttachmentUrlPrefix(AListProperties properties,
+        AListGetCurrentUserInfoRes userInfoRes) {
+        return properties.getAttachmentUrlPrefix() != null
+            ? properties.getAttachmentUrlPrefix().toString()
+            : fromUriString(properties.getSite().toString())
+                .path("/d{basePath}")
+                .buildAndExpand(userInfoRes.getBasePath())
+                .toUriString();
     }
 
     private Mono<AListGetFileInfoRes> getFile(String token,

--- a/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
+++ b/src/main/java/run/halo/alist/endpoint/AListAttachmentHandler.java
@@ -280,7 +280,7 @@ public class AListAttachmentHandler implements AttachmentHandler {
                                 new ParameterizedTypeReference<AListResult<AListGetCurrentUserInfoRes>>() {
                                 })
                             .map(userInfoRes -> fromUriString(
-                                    getAttachmentUrlPrefix(properties, userInfoRes.getData()))
+                                    getExternalUrl(properties, userInfoRes.getData()))
                                 .path("{path}/{name}")
                                 .queryParamIfPresent("sign",
                                     Optional.ofNullable(fileInfo.getSign())
@@ -294,10 +294,10 @@ public class AListAttachmentHandler implements AttachmentHandler {
             });
     }
 
-    private String getAttachmentUrlPrefix(AListProperties properties,
+    private String getExternalUrl(AListProperties properties,
         AListGetCurrentUserInfoRes userInfoRes) {
-        return properties.getAttachmentUrlPrefix() != null
-            ? properties.getAttachmentUrlPrefix().toString()
+        return properties.getExternalUrl() != null
+            ? properties.getExternalUrl().toString()
             : fromUriString(properties.getSite().toString())
                 .path("/d{basePath}")
                 .buildAndExpand(userInfoRes.getBasePath())

--- a/src/main/resources/extensions/policy-template-alist.yaml
+++ b/src/main/resources/extensions/policy-template-alist.yaml
@@ -24,6 +24,10 @@ spec:
               validation: required
               help: AList 站点地址，如 https://alist.example.com
             - $formkit: text
+              name: attachmentUrlPrefix
+              label: 附件访问前缀
+              help: 附件访问链接前缀，将基于此前缀拼接挂载路径和文件名，如 https://alist.example.com/d/base-path，留空时默认为 {站点}/d{基本路径}
+            - $formkit: text
               name: path
               label: 挂载路径
               help: 所填用户基本路径(可在 AList 管理 -> 用户 查看)下文件夹的路径，必须以 / 开头，支持多级目录如 /picture/2024，则全路径为{基本路径}/picture/2024，上传文件时会自动创建不存在的目录，留空表示基本路径根目录 /

--- a/src/main/resources/extensions/policy-template-alist.yaml
+++ b/src/main/resources/extensions/policy-template-alist.yaml
@@ -24,9 +24,9 @@ spec:
               validation: required
               help: AList 站点地址，如 https://alist.example.com
             - $formkit: text
-              name: attachmentUrlPrefix
-              label: 附件访问前缀
-              help: 附件访问链接前缀，将基于此前缀拼接挂载路径和文件名，如 https://alist.example.com/d/base-path，留空时默认为 {站点}/d{基本路径}
+              name: externalUrl
+              label: 外部访问链接
+              help: AList 外部访问链接，如设置为 https://alist.example.com/d/base 时，文件外部访问地址为 https://alist.example.com/d/base/{挂载路径}/{文件名}，留空时默认为 {站点}/d{基本路径}
             - $formkit: text
               name: path
               label: 挂载路径

--- a/src/main/resources/extensions/policy-template-alist.yaml
+++ b/src/main/resources/extensions/policy-template-alist.yaml
@@ -25,8 +25,8 @@ spec:
               help: AList 站点地址，如 https://alist.example.com
             - $formkit: text
               name: externalUrl
-              label: 外部访问链接
-              help: AList 外部访问链接，如设置为 https://alist.example.com/d/base 时，文件外部访问地址为 https://alist.example.com/d/base/{挂载路径}/{文件名}，留空时默认为 {站点}/d{基本路径}
+              label: 附件访问前缀
+              help: 附件外部访问地址前缀。填写后将替换默认外部访问地址中的 {站点}/d{基本路径} 部分；例如设置为 https://file.example.com/example 时，外部访问地址为 https://file.example.com/example{挂载路径}/{文件名}。留空时默认为 {站点}/d{基本路径}
             - $formkit: text
               name: path
               label: 挂载路径


### PR DESCRIPTION
Fixes: #14 

添加`附件访问前缀`配置项。
若站点地址为`https://alist.example.com`，基本路径为`basepath`，挂载路径为`path`，文件名为`filename`，则附件访问地址为`https://alist.example.com/d/basepath/path/filename`。
当附件访问前缀配置为`https://file.example.com/example`时，附件访问地址为`https://file.example.com/example/path/filename`。
即填写了附件访问前缀后，将使用填写的前缀替换未填写时附件访问地址中的`https://alist.example.com/d/basepath`部分。
此配置项仅影响附件对外访问地址，上传、删除、验证仍使用原本的站点地址。

/kind improvement

```release-note
添加附件访问前缀配置项
```
